### PR TITLE
Redesign homepage with minimal layout and new sections

### DIFF
--- a/my-website/app/components/GlitchText.tsx
+++ b/my-website/app/components/GlitchText.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+
+const GLITCH_CHARS = "!<>-_\\/[]{}—=+*^?#________";
+const SCRAMBLE_MS = 600;
+const FRAME_MS = 40;
+
+interface GlitchTextProps {
+  text: string;
+  className?: string;
+}
+
+const GlitchText: React.FC<GlitchTextProps> = ({ text, className }) => {
+  const [display, setDisplay] = useState(text);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const startRef = useRef<number>(0);
+
+  const stop = () => {
+    if (intervalRef.current) {
+      clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+    setDisplay(text);
+  };
+
+  const scramble = () => {
+    if (intervalRef.current) return;
+    startRef.current = performance.now();
+
+    intervalRef.current = setInterval(() => {
+      const elapsed = performance.now() - startRef.current;
+      const progress = Math.min(elapsed / SCRAMBLE_MS, 1);
+      const resolvedCount = Math.floor(progress * text.length);
+
+      let next = "";
+      for (let i = 0; i < text.length; i++) {
+        if (text[i] === " ") {
+          next += " ";
+        } else if (i < resolvedCount) {
+          next += text[i];
+        } else {
+          next += GLITCH_CHARS[Math.floor(Math.random() * GLITCH_CHARS.length)];
+        }
+      }
+      setDisplay(next);
+
+      if (progress >= 1) {
+        stop();
+      }
+    }, FRAME_MS);
+  };
+
+  useEffect(() => {
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+    };
+  }, []);
+
+  return (
+    <span
+      className={className}
+      onMouseEnter={scramble}
+      onFocus={scramble}
+      tabIndex={0}
+      style={{ display: "inline-block" }}
+    >
+      {display}
+    </span>
+  );
+};
+
+export default GlitchText;

--- a/my-website/app/components/Header.tsx
+++ b/my-website/app/components/Header.tsx
@@ -60,7 +60,6 @@ const Header = () => {
           <div className="hidden md:flex items-center space-x-4">
             <Link href="/projects">projects</Link>
             <Link href="/writing">writing</Link>
-            <Link href="/experiences">experience</Link>
             <Link href="/Zikora_Chinedu_resume.pdf">resume</Link>
             <Link href="/reading">reading</Link>
             <ThemeToggle />
@@ -97,13 +96,6 @@ const Header = () => {
               onClick={() => setIsMobileMenuOpen(false)}
             >
               writing
-            </Link>
-            <Link
-              href="/experiences"
-              className="hover:text-muted-foreground transition-colors"
-              onClick={() => setIsMobileMenuOpen(false)}
-            >
-              experience
             </Link>
             <Link
               href="/Zikora_Chinedu_resume.pdf"

--- a/my-website/app/components/Hero.tsx
+++ b/my-website/app/components/Hero.tsx
@@ -1,319 +1,399 @@
-import React from "react";
-import Image from "next/image";
-import WealthSeedLogo from "@/app/components/icons/WealthseedLogo.jpg";
-import UofTLogo from "@/app/components/icons/UofTLogo.jpg";
-import BlackInStemLogo from "@/app/components/icons/blackinstem.jpg";
+"use client";
+
+import React, { useState } from "react";
+import Image, { StaticImageData } from "next/image";
+import Link from "next/link";
+import { motion, AnimatePresence } from "motion/react";
 import Zikora from "@/app/components/icons/zikora.jpg";
+import WealthSeedLogo from "@/app/components/icons/WealthseedLogo.jpg";
 import RiskLab from "@/app/components/icons/RiskLab.png";
 import Ontario from "@/app/components/icons/ontario.png";
 import OntarioDark from "@/app/components/icons/ontario-dark.png";
 import Sharpe from "@/app/components/icons/sharpe.webp";
 import UofTAILogo from "@/app/components/icons/UofTAI_Logo.png";
 import BorderPassLogo from "@/app/components/icons/BorderPass.jpeg";
-import Link from "next/link";
-import * as motion from "motion/react-client";
-import AnimatedBulletPoint from "./AnimatedBulletPoint";
+import GlitchText from "./GlitchText";
+import { currentlyReading } from "../reading/data";
+import type { ArticleMetadata } from "@/lib/mdx";
 
-const Hero = () => {
-  const sectionVariants = {
-    hidden: { opacity: 0, y: 20 },
-    visible: {
-      opacity: 1,
-      y: 0,
-      transition: {
-        duration: 0.5,
-        staggerChildren: 0.1,
-      },
-    },
-  };
+interface Experience {
+  title: string;
+  company: string;
+  logo: StaticImageData;
+  logoDark?: StaticImageData;
+  date: string;
+  tagline?: string;
+  description?: string[];
+  href?: string;
+}
 
-  const itemVariants = {
-    hidden: { opacity: 0, y: 15 },
-    visible: { opacity: 1, y: 0, transition: { duration: 0.4 } },
-  };
+const experiences: Experience[] = [
+  {
+    title: "Incoming SWE",
+    company: "BorderPass",
+    logo: BorderPassLogo,
+    date: "May – Aug 2026",
+    tagline: "AI-powered immigration platform",
+    href: "https://borderpass.ai",
+  },
+  {
+    title: "Web Developer",
+    company: "UofT AI",
+    logo: UofTAILogo,
+    date: "Jan – Mar 2026",
+    href: "https://uoft.ai",
+  },
+  {
+    title: "Research Assistant",
+    company: "RiskLab",
+    logo: RiskLab,
+    date: "May 2025 – Jan 2026",
+    href: "https://risklab.ca",
+  },
+  {
+    title: "Software Engineer Intern",
+    company: "Ontario Public Service",
+    logo: Ontario,
+    logoDark: OntarioDark,
+    date: "May – Aug 2025",
+    tagline: "Internal collaboration platform",
+    description: [
+      "Built a collaboration platform serving 400+ OPS employees, with anonymous posting and AI-powered content enhancement that increased post engagement by 40% in user testing.",
+      "Shipped 15+ responsive React/TypeScript components with Tailwind, optimized via lazy loading and memoization to hit a 93 Lighthouse score and sub-2s loads.",
+      "Built a super admin interface on Express.js with PostgreSQL/Drizzle, cutting manual oversight time by 50%.",
+    ],
+    href: "https://www.ontario.ca/page/government-ontario",
+  },
+  {
+    title: "Founding Engineer",
+    company: "Wealthseed",
+    logo: WealthSeedLogo,
+    date: "Jan – Sep 2025",
+    tagline: "Financial e-learning platform",
+    description: [
+      "Built the frontend of a financial e-learning platform: notification system, multi-role auth, and a responsive course management UI for students and teachers.",
+      "Implemented auth with NextAuth.js (JWT + bcrypt) supporting role-based access for students, teachers, and admins across multiple schools.",
+      "Built a real-time notification system with conditional rendering and state management, cutting page loads by 25%.",
+    ],
+    href: "https://wealthseed.ca",
+  },
+  {
+    title: "Quantitative Finance Analyst",
+    company: "Sharpe Financial Research Group",
+    logo: Sharpe,
+    date: "Jul 2024 – Apr 2025",
+    tagline: "Algorithmic trading research",
+    description: [
+      "Developed and backtested algorithmic trading strategies using statistical and ML techniques.",
+      "Built advanced financial models and conducted quantitative research.",
+    ],
+    href: "https://www.sharpe-research.com",
+  },
+];
 
-  const listVariants = {
-    hidden: { opacity: 0 },
-    visible: {
-      opacity: 1,
-      transition: {
-        staggerChildren: 0.15,
-        delayChildren: 0.2,
-      },
-    },
-  };
+const INITIAL_VISIBLE = 2;
 
-  const listItemVariants = {
-    hidden: { opacity: 0, x: -10 },
-    visible: { opacity: 1, x: 0, transition: { duration: 0.3 } },
-    hover: { x: 4, transition: { duration: 0.2 } },
-  };
+interface HeroProps {
+  articles: ArticleMetadata[];
+}
+
+const formatDate = (date: string) => {
+  if (date === "Living Document") return date;
+  const parsed = new Date(date);
+  if (Number.isNaN(parsed.getTime())) return date;
+  return parsed.toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+};
+
+const SectionLabel: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => <h2 className="text-xl font-bold mb-4">{children}</h2>;
+
+const ExperienceRow: React.FC<{
+  exp: Experience;
+  isOpen: boolean;
+  onToggle: () => void;
+}> = ({ exp, isOpen, onToggle }) => {
+  const hasDetail = !!exp.description?.length;
+
+  const row = (
+    <div className="flex items-center gap-4 py-4">
+      <div className="w-10 h-10 relative flex-shrink-0">
+        {exp.logoDark ? (
+          <>
+            <Image
+              src={exp.logo}
+              alt={exp.company}
+              fill
+              className="object-contain rounded-md dark:hidden"
+            />
+            <Image
+              src={exp.logoDark}
+              alt={exp.company}
+              fill
+              className="object-contain rounded-md hidden dark:block"
+            />
+          </>
+        ) : (
+          <Image
+            src={exp.logo}
+            alt={exp.company}
+            fill
+            className="object-contain rounded-md"
+          />
+        )}
+      </div>
+      <div className="flex-1 min-w-0">
+        <div className="flex flex-wrap items-baseline gap-x-2">
+          <span className="text-foreground font-medium">{exp.title}</span>
+          <span className="text-muted-foreground">{exp.company}</span>
+        </div>
+        {exp.tagline && (
+          <p className="text-sm text-muted-foreground mt-0.5 truncate">
+            {exp.tagline}
+          </p>
+        )}
+      </div>
+      <span className="text-sm text-muted-foreground whitespace-nowrap hidden sm:block">
+        {exp.date}
+      </span>
+      <svg
+        className={`w-4 h-4 text-muted-foreground flex-shrink-0 transition-transform duration-200 ${
+          isOpen ? "rotate-180" : ""
+        } ${hasDetail ? "" : "opacity-30"}`}
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M19 9l-7 7-7-7"
+        />
+      </svg>
+    </div>
+  );
+
+  return (
+    <li>
+      {hasDetail ? (
+        <button
+          onClick={onToggle}
+          className="w-full text-left cursor-pointer hover:bg-muted/30 transition-colors rounded-sm"
+          aria-expanded={isOpen}
+        >
+          {row}
+        </button>
+      ) : (
+        <div>{row}</div>
+      )}
+      <AnimatePresence initial={false}>
+        {isOpen && hasDetail && (
+          <motion.div
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2, ease: "easeInOut" }}
+            className="overflow-hidden"
+          >
+            <div className="pl-14 pr-4 pb-5 space-y-3">
+              <ul className="space-y-2 text-sm text-muted-foreground leading-relaxed list-disc pl-4">
+                {exp.description!.map((point, pi) => (
+                  <li key={pi}>{point}</li>
+                ))}
+              </ul>
+              {exp.href && (
+                <Link
+                  href={exp.href}
+                  target="_blank"
+                  className="inline-block text-sm text-muted-foreground underline underline-offset-4 hover:text-foreground"
+                >
+                  visit →
+                </Link>
+              )}
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </li>
+  );
+};
+
+const Hero: React.FC<HeroProps> = ({ articles }) => {
+  const [openIdx, setOpenIdx] = useState<number | null>(null);
+  const [showAllExperience, setShowAllExperience] = useState(false);
+
+  const visibleExperiences = showAllExperience
+    ? experiences
+    : experiences.slice(0, INITIAL_VISIBLE);
+
+  const recentArticles = articles.slice(0, 3);
+
+  const underlineLink =
+    "underline underline-offset-4 decoration-muted-foreground/40 hover:decoration-foreground";
 
   return (
     <div>
       <motion.section
-        className="flex flex-col md:flex-row items-center"
-        initial="hidden"
-        animate="visible"
-        variants={{
-          hidden: { opacity: 0 },
-          visible: { opacity: 1, transition: { staggerChildren: 0.2 } },
-        }}
+        className="pt-8 pb-12 flex items-start justify-between gap-4"
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5 }}
       >
-        <motion.div
-          className="w-full md:w-[40%] p-5 md:pl-0 flex justify-center"
-          variants={{
-            hidden: { opacity: 0, x: -50 },
-            visible: {
-              opacity: 1,
-              x: 0,
-              transition: { duration: 0.5 },
-            },
-          }}
-        >
+        <h1 className="text-5xl md:text-7xl font-sans leading-none">
+          <GlitchText text="Zikora Chinedu" />
+        </h1>
+        <div className="w-12 h-12 md:w-14 md:h-14 relative flex-shrink-0 mt-2">
           <Image
             src={Zikora}
-            alt="Picture of Zikora"
-            width={300}
-            height={300}
-            className="object-contain rounded-lg"
+            alt="Zikora"
+            fill
+            className="object-cover rounded-full"
           />
-        </motion.div>
-        <motion.div
-          className="w-full md:w-[60%] flex items-center justify-start md:pl-5 mt-4 md:mt-0"
-          variants={{
-            hidden: { opacity: 0, x: 50 },
-            visible: {
-              opacity: 1,
-              x: 0,
-              transition: { duration: 0.5 },
-            },
-          }}
-        >
-          <div className="font-sans text-4xl sm:text-5xl md:text-8xl text-center md:text-left w-full">
-            <motion.span
-              className="inline-block mr-4"
-              variants={listItemVariants}
-              whileHover="hover"
-            >
-              Zikora
-            </motion.span>
-            <motion.span
-              className="inline-block"
-              variants={listItemVariants}
-              whileHover="hover"
-            >
-              Chinedu
-            </motion.span>
-          </div>
-        </motion.div>
+        </div>
       </motion.section>
 
       <motion.section
-        className="space-y-2 leading-relaxed mt-8 text-left"
-        initial="hidden"
-        animate="visible"
-        variants={sectionVariants}
+        className="pb-12"
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5, delay: 0.12 }}
       >
-        <div className="mx-4 md:mx-0">
-          <AnimatedBulletPoint>
-            Incoming SWE @{" "}
-            <span className="font-semibold text-[#5ac3aa] dark:text-[#e5ef6f] inline-flex items-baseline">
-              <Image
-                src={BorderPassLogo}
-                alt="BorderPass Logo"
-                width={23}
-                height={23}
-                className="object-contain relative top-[3px] rounded-xs ml-0 mr-2"
-              />
-              <Link href="https://borderpass.ai">BorderPass</Link>
-            </span>
-          </AnimatedBulletPoint>
-          <AnimatedBulletPoint>
-            cs @{" "}
-            <span className="font-semibold text-[#002b65] dark:text-white inline-flex items-baseline">
-              <Image
-                src={UofTLogo}
-                alt="UofT Logo"
-                width={20}
-                height={20}
-                className="object-contain relative top-[3px] rounded-xs ml-0"
-              />
-              <Link href="https://utoronto.ca/">University of Toronto</Link>
-            </span>
-          </AnimatedBulletPoint>
-        </div>
-
-        <div className="group hover:translate-x-1 transition-transform duration-200">
-          <motion.p variants={itemVariants} className="italic text-[18px] pt-4">
-            Currently:
-          </motion.p>
-          <motion.ul
-            className="list-disc pl-5 md:pl-8 space-y-1 text-[18px] text-left"
-            variants={listVariants}
-          >
-            <motion.li variants={listItemVariants} whileHover="hover">
-              VP Computer Science @ {""}
-              <span className="inline-flex items-baseline gap-1">
-                <Image
-                  src={BlackInStemLogo}
-                  alt="BlackInStem Logo"
-                  width={20}
-                  height={20}
-                  className="object-contain relative top-[3px] rounded-xs ml-0"
-                />
-                <Link href="https://www.linkedin.com/company/black-in-stem-utm/">
-                  BlackInStem.
-                </Link>
-              </span>
-            </motion.li>
-            <motion.li variants={listItemVariants} whileHover="hover">
-              In my 3rd year at UofT, studying a Computer Science Major, with
-              minors in Mathematics and Statistics.
-            </motion.li>
-            <motion.li variants={listItemVariants} whileHover="hover">
-              Writing on occasion. Check my blogs out{" "}
-              <Link href="/writing" className="underline">
-                here.
-              </Link>
-            </motion.li>
-          </motion.ul>
-        </div>
-        <div className="group hover:translate-x-1 transition-transform duration-200">
-          <motion.p variants={itemVariants} className="italic text-[18px] pt-4">
-            Previously:
-          </motion.p>
-          <motion.ul
-            className="list-disc pl-5 md:pl-8 space-y-1 text-[18px] text-left"
-            variants={listVariants}
-          >
-            <motion.li variants={listItemVariants} whileHover="hover">
-              Web Developer @{" "}
-              <span className="font-semibold text-[#6275dd] dark:text-[#c171e9] inline-flex items-baseline">
-                <Image
-                  src={UofTAILogo}
-                  alt="UofTAI Logo"
-                  width={20}
-                  height={20}
-                  className="object-contain relative top-[3px] rounded-xs ml-0 mr-2"
-                />
-                <Link href="https://utoronto.ca/">UofT AI</Link>
-              </span>
-            </motion.li>
-            <motion.li variants={listItemVariants} whileHover="hover">
-              Research Assistant @{" "}
-              <span className="font-semibold text-[#ad1d36] dark:text-[#f4c122] inline-flex items-baseline">
-                <Image
-                  src={RiskLab}
-                  alt="RiskLab Logo"
-                  width={20}
-                  height={20}
-                  className="object-contain relative top-[3px] rounded-xs ml-0 mr-2"
-                />
-                <Link href="https://risklab.ca/">RiskLab</Link>
-              </span>
-            </motion.li>
-            <motion.li variants={listItemVariants} whileHover="hover">
-              Founding Engineer @ {""}
-              <span className="inline-flex items-baseline gap-1">
-                <Image
-                  src={WealthSeedLogo}
-                  alt="Wealthseed Logo"
-                  width={20}
-                  height={20}
-                  className="object-contain relative top-[3px] rounded-xs ml-1 mr-1"
-                />
-                <Link href="https://wealthseed.ca">Wealthseed.</Link>
-              </span>
-            </motion.li>
-            <motion.li variants={listItemVariants} whileHover="hover">
-              Software Engineer Intern @ {""}
-              <span className="inline-flex items-baseline gap-1">
-                <Image
-                  src={Ontario}
-                  alt="Ontario Logo"
-                  width={20}
-                  height={20}
-                  className="object-contain relative top-[3px] rounded-xs ml-1 mr-1 dark:hidden"
-                />
-                <Image
-                  src={OntarioDark}
-                  alt="Ontario Logo"
-                  width={20}
-                  height={20}
-                  className="object-contain relative top-[3px] rounded-xs ml-1 mr-1 hidden dark:block"
-                />
-                <Link href="https://www.ontario.ca/page/government-ontario">
-                  Ontario Public Service.
-                </Link>
-              </span>
-            </motion.li>
-            <motion.li variants={listItemVariants} whileHover="hover">
-              Quantitative Finance Analyst @ {""}
-              <span className="inline-flex items-baseline gap-1">
-                <Image
-                  src={Sharpe}
-                  alt="Sharpe Logo"
-                  width={20}
-                  height={20}
-                  className="object-contain relative top-[3px] rounded-xs ml-1 mr-1 dark:bg-neutral-50"
-                />
-                <Link href="https://www.sharpe-research.com/">
-                  Sharpe Financial Research Group.
-                </Link>
-              </span>
-            </motion.li>
-          </motion.ul>
-        </div>
-
-        <div className="group hover:translate-x-1 transition-transform duration-200">
-          <motion.p variants={itemVariants} className="italic text-[18px] pt-4">
-            Some things about me:
-          </motion.p>
-          <motion.ul
-            className="list-disc pl-5 md:pl-8 space-y-1 text-[18px] text-left"
-            variants={listVariants}
-          >
-            <motion.li variants={listItemVariants} whileHover="hover">
-              I&apos;m interested in machine learning and software engineering,
-              and in particular its intersection with the financial space.{" "}
-            </motion.li>
-            <motion.li variants={listItemVariants} whileHover="hover">
-              I am an avid reader. You can check out my reading list/reviews{" "}
-              <Link href="/reading" className="underline">
-                here
-              </Link>
-              .{" "}
-            </motion.li>
-            <motion.li variants={listItemVariants} whileHover="hover">
-              I love getting active. I play soccer (Arsenal fan), basketball,
-              and I hit the gym.{" "}
-            </motion.li>
-            <motion.li variants={listItemVariants} whileHover="hover">
-              I enjoy playing the piano, playing chess, doing{" "}
-              <Link
-                href="https://monkeytype.com/profile/zikompo"
-                className="underline"
-              >
-                typing tests
-              </Link>{" "}
-              and watching YouTube mini-documentaries.
-            </motion.li>
-            <motion.li variants={listItemVariants} whileHover="hover">
-              I love talking about economics, current affairs, and philosophical
-              questions. You can get in{" "}
-              <Link
-                href="mailto:zikora.chinedu@yahoo.com"
-                className="underline"
-              >
-                contact
-              </Link>{" "}
-              with me if you want to have a discussion!
-            </motion.li>
-          </motion.ul>
+        <SectionLabel>About</SectionLabel>
+        <div className="space-y-4 text-[18px] leading-relaxed">
+          <p>
+            Third year CS student at{" "}
+            <Link href="https://utoronto.ca" className={underlineLink}>
+              University of Toronto
+            </Link>
+            , incoming SWE at{" "}
+            <Link href="https://borderpass.ai" className={underlineLink}>
+              BorderPass
+            </Link>{" "}
+            for the summer.
+          </p>
+          <p>
+            Interested in machine learning and software engineering, especially
+            at the intersection with finance.
+          </p>
         </div>
       </motion.section>
+
+      <motion.section
+        className="pb-12"
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5, delay: 0.2 }}
+      >
+        <SectionLabel>Reading</SectionLabel>
+        <div className="space-y-2 text-[18px] leading-relaxed">
+          <p>
+            Currently reading{" "}
+            <Link
+              href={currentlyReading.url}
+              target="_blank"
+              className={underlineLink}
+            >
+              <i>{currentlyReading.title}</i>
+            </Link>{" "}
+            by {currentlyReading.author}.
+          </p>
+          <p>
+            Check out the rest of my reading{" "}
+            <Link href="/reading" className={underlineLink}>
+              here
+            </Link>
+            .
+          </p>
+        </div>
+      </motion.section>
+
+      <motion.section
+        className="pb-12"
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.5, delay: 0.28 }}
+      >
+        <SectionLabel>Experience</SectionLabel>
+        <ul className="divide-y divide-border">
+          {visibleExperiences.map((exp, i) => (
+            <ExperienceRow
+              key={exp.company}
+              exp={exp}
+              isOpen={openIdx === i}
+              onToggle={() => setOpenIdx(openIdx === i ? null : i)}
+            />
+          ))}
+        </ul>
+        {experiences.length > INITIAL_VISIBLE && (
+          <button
+            onClick={() => {
+              if (showAllExperience) setOpenIdx(null);
+              setShowAllExperience(!showAllExperience);
+            }}
+            className="mt-3 text-sm text-muted-foreground hover:text-foreground transition-colors inline-flex items-center gap-1"
+          >
+            {showAllExperience
+              ? "Show less"
+              : `Show all (${experiences.length})`}
+            <svg
+              className={`w-3.5 h-3.5 transition-transform duration-200 ${
+                showAllExperience ? "rotate-180" : ""
+              }`}
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M19 9l-7 7-7-7"
+              />
+            </svg>
+          </button>
+        )}
+      </motion.section>
+
+      {recentArticles.length > 0 && (
+        <motion.section
+          className="pb-12"
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, delay: 0.36 }}
+        >
+          <SectionLabel>Writing</SectionLabel>
+          <ul className="divide-y divide-border">
+            {recentArticles.map((article) => (
+              <li key={article.slug}>
+                <Link
+                  href={`/writing/${article.slug}`}
+                  className="flex items-baseline justify-between gap-4 py-3 hover:bg-muted/30 transition-colors rounded-sm px-1 -mx-1"
+                >
+                  <span className="text-foreground">{article.title}</span>
+                  <span className="text-sm text-muted-foreground whitespace-nowrap">
+                    {formatDate(article.date)}
+                  </span>
+                </Link>
+              </li>
+            ))}
+          </ul>
+          {articles.length > 3 && (
+            <Link
+              href="/writing"
+              className="mt-3 text-sm text-muted-foreground hover:text-foreground transition-colors inline-block"
+            >
+              All writing →
+            </Link>
+          )}
+        </motion.section>
+      )}
     </div>
   );
 };
+
 export default Hero;

--- a/my-website/app/page.tsx
+++ b/my-website/app/page.tsx
@@ -1,15 +1,14 @@
-// app/page.tsx
-"use client";
 import Hero from "@/app/components/Hero";
 import Layout from "./components/Layout";
+import { getAllArticles } from "@/lib/mdx";
 
-import React from "react";
+export default async function Home() {
+  const articles = await getAllArticles();
 
-export default function Home() {
   return (
     <div className="text-zinc-800 text-[23px]">
       <Layout>
-        <Hero />
+        <Hero articles={articles} />
       </Layout>
     </div>
   );

--- a/my-website/app/reading/data.ts
+++ b/my-website/app/reading/data.ts
@@ -1,0 +1,171 @@
+export interface BookReview {
+  title: string;
+  author: string;
+  imageUrl: string;
+  rating: number;
+  review: string[];
+}
+
+export const currentlyReading = {
+  title: "A Peace to End All Peace",
+  author: "David Fromkin",
+  url: "https://www.amazon.ca/Peace-End-All-Ottoman-Creation/dp/0805088091",
+};
+
+export const bookReviews: BookReview[] = [
+  {
+    title: "Thinking in Bets",
+    author: "Annie Duke",
+    imageUrl: "https://m.media-amazon.com/images/I/71WOIOz0ihL._SY522_.jpg",
+    rating: 4,
+    review: [
+      "It is a good book for someone who wants to learn about decision making and how to make better decisions.",
+      "I got into it because I recently started playing poker and wanted to understand the psychology behind making decisions when you have incomplete information.",
+      "It's more of a theoretical book, but it's still a good read in my opinion.",
+    ],
+  },
+  {
+    title: "The Psychology of Money",
+    author: "Morgan Housel",
+    imageUrl: "https://images.renaud-bray.com/images/PG/3440/3440245-gf.jpg",
+    rating: 4,
+    review: [
+      "Great book for someone wanting to understand the emotional and psychological factors that drive our financial decisions. Talks a lot about how our upbringing and experiences shape the way we think about money.",
+      "Has a lot of good anecdotes that make the book engaging, and it's an easy read.",
+      "In a practical sense, Morgan Housel talks about how he approaches saving/investing, but it's not a how-to-book. I saw it more as an insightful book.",
+    ],
+  },
+  {
+    title: "Man's Search for Meaning",
+    author: "Viktor Frankl",
+    imageUrl: "https://m.media-amazon.com/images/I/612eTMIpONS._SY522_.jpg",
+    rating: 4.5,
+    review: [
+      "Great book. It was very touching, and there were multiple moments where I had to pause and reflect to try and imagine going through the inhumane conditions that the author and others in the concentration camps had to endure.",
+      "The book is about Viktor Frankl's experiences in the concentration camps during WW2 and how he found meaning in his life despite the horrors he endured. He also details methods for finding purpose, such as suffering with dignity.",
+      "Potentially one of the best books I've read this year.",
+    ],
+  },
+  {
+    title: "The Count of Monte Cristo",
+    author: "Alexandre Dumas",
+    imageUrl: "https://m.media-amazon.com/images/I/811iBn28JdL._SY522_.jpg",
+    rating: 5,
+    review: [
+      "This book is THE revenge tale, and probably one of the best books I've ever read.",
+      "The story follows Edmond Dantès, a young sailor who is wrongfully imprisoned and seeks revenge on those who betrayed him.",
+      "The way he goes about his retribution is both very clever and calculated, and despite being over 1200 pages long, it was a page-turner from start to finish. It has everything you could want in a book: adventure, romance, betrayal, and revenge.",
+      "This was my first time reading a fiction book in a long time, and I think I will get back into reading more fiction after this.",
+      "Amazing read, and a deserved 5 stars.",
+    ],
+  },
+  {
+    title: "Educated",
+    author: "Tara Westover",
+    imageUrl: "https://m.media-amazon.com/images/I/418dkB1gnxL.jpg",
+    rating: 4,
+    review: [
+      "Was a very interesting read, and rather empowering. This book follows the life of Tara, a woman who grew up in an extremely fundamentalist Mormon household, where she was denied access to education. It details how she gradually educates herself and eventually goes on to earn a PhD from Cambridge University.",
+      "The book is well-written and engaging. I got rather angry at some parts, especially when she detailed the abuse she and her siblings endured at the hands of their father/brother, and how her family refused to acknowledge it. I even got more frustrated when she kept going back to her family despite the abuse, but I guess that's the power of family.",
+      "It was inspiring overall, seeing someone overcome such adversity to attain such a high level of education. Overall a good read.",
+    ],
+  },
+  {
+    title: "Flowers for Algernon",
+    author: "Daniel Keyes",
+    imageUrl: "https://m.media-amazon.com/images/I/81HntONlwgL._SY522_.jpg",
+    rating: 4.5,
+    review: [
+      "This book was very touching. It follows the story of Charlie, a man who initially suffers from severe mental disabilities, but undergoes a brain surgery that gives him intelligence.",
+      "It reminded me of the importance of showing compassion and empathy towards people different from us. It was kind of sad at times to see how Charlie slowly realized that everyone around him didn't actually care about him, and made fun of him just because he was different.",
+      "It was also interesting to see how Charlie's intelligence grew over time, and made him less and less relatable, and even at times arrogant.",
+      "Seeing his eventual mental decline was very saddening, and it left me in a sort of somber mood for a while after reading it.",
+      "I'd recommend this book. It was the first time I've read a fiction book that was written in the form of journal entries, and it surely surpassed my expectations.",
+    ],
+  },
+  {
+    title: "A Spy Among Friends",
+    author: "Ben Macintyre",
+    imageUrl: "https://m.media-amazon.com/images/I/81grRR9GmML._SY522_.jpg",
+    rating: 4,
+    review: [
+      "This book is a non-fiction that tells the story of famed British spy Kim Philby, who was actually a double agent for the Soviet Union. It details his life, his relationships with other spies, and the eventual uncoverning of his betrayal.",
+      "It kind of surprised me how Philby was able to maintain his cover for so long, and how his closest friends backed him vehemently despite the mounting evidence against him. It was also kind of crazy how Philby basically undermined Western intelligence operations against the Soviets for two decades.",
+      "It gave me new perspective on betrayal, and how people can let their personal relationships get in the way of their professional responsibilities.",
+      "It was a good read, and it gave me a new perspective on the Cold War and the role of intelligence agencies in the push to change the ideological landscape of the world.",
+    ],
+  },
+  {
+    title: "East of Eden",
+    author: "John Steinbeck",
+    imageUrl: "https://m.media-amazon.com/images/I/71NAX4mpJHL._SY522_.jpg",
+    rating: 5,
+    review: [
+      "Possibly the best book I've ever read.",
+      "This book goes into the lives of two families, the Trasks and the Hamiltons, who lived in California. This book spans a couple of generations, from around the mid-19th century to the early 20th century.",
+      "It is essentially a modern American retelling of the biblical story of Cain and Abel, and the themes are rather prevalent throughout the book. Across each generation, you can draw parallels between the events in the story and the story from the Book of Genesis. It also touches on the themes of good and evil, examining whether humans can be inherently good or evil. It asks whether we are doomed to repeat the transgressions of our ancestors, or we can form our own moral paths.",
+      'A key word in this whole thing is Timshel, which was interpreted in East of Eden as "Thou mayest" (I understand that this is not the literal translation). In the context of the book, I think Steinbeck was trying to convey the message that humans have free will to choose whether to be good or evil, independent of what their nature may be.',
+      "The book was so wonderfully written. John Steinbeck's prose is rather straightforward, but very beautifully written. His characterization was also top notch, and I sort of grew attached to the characters in the book. Lee and Cal are my favourite characters in the book. Lee for his wisdom and charisma. Cal, because he was a flawed person, but he was a joy to follow, and his battles with identity and morality are things I can somewhat relate to.",
+      "I also loved following Cathy. She seemed to be evil for the sake of it, but that made her more interesting. I never figured out what her endgame was. Samuel Hamilton is probably my favourite character after Lee and Cal. He was the poster boy for someone following his dreams and passions.",
+      "All in all, this book was very enjoyable with a lot of wisdom scattered throughout the book, if you choose to look for it. Easy 5 star, and an easy recommendation from me.",
+    ],
+  },
+  {
+    title: "1984",
+    author: "George Orwell",
+    imageUrl:
+      "https://m.media-amazon.com/images/I/51yNeZ+SDOL._SY445_SX342_ControlCacheEqualizer_.jpg",
+    rating: 4,
+    review: [
+      "(Shorter Review because of exams)",
+      "It's a good book.",
+      "1984 is set in a dystopian, totalitarian province within the superstate of Oceania. Specifically, it's set in London, where its protagonist Winston lives and works under the watchful eye of The Party and its leader, Big Brother.",
+      "I found it a bit of a drag at first, but it picked up and got more interesting as the book went on.",
+      "I'd say it's pretty relevant today given current events in the world today, and it serves as a cautionary tale of some sorts. It does a good job of portraying a surveillance state, where the past is altered, and even the language is narrowed down to keep people as obedient as possible.",
+      "The book is worth reading, IMO.",
+    ],
+  },
+  {
+    title: "The Art of Spending Money",
+    author: "Morgan Housel",
+    imageUrl: "https://m.media-amazon.com/images/I/71Pusl9N1AL._SL1500_.jpg",
+    rating: 4.5,
+    review: [
+      "This book talks a lot about the different social and psychological factors that go into our spending habits, and how we can understand their effects on our financial well-being.",
+      "I resonated with a lot of the book, and I will definitely be using a lot of the advice in this book when I start my co-op job, as it will be the first time I have a good amount of disposable income.",
+      "The number one thing I took away from the book is that anyone's behavior makes sense with enough information. The person who lost all their money in the 2008/2009 financial crisis may be very conservative with their investments, but the young person who has never had to worry about money may be a lot less risk averse, or even reckless.",
+      "The author also had a very interesting way of looking at saving money. He viewed saving money as a payment, the same way you'd pay for clothes, or food. But when you save money, you are paying towards your future independence. So saving $100 dollars today could be seen as giving yourself $100 dollars of freedom tomorrow.",
+      "It is also important to not have FOMO, and walk your journey. Easier said than done, but you should have a view of what you want your life to look like, and stay true to it.",
+      "I believe this book is a great, practical book for people looking into helping people reshape their relationship with money. The book is also incredibly dense with great quotes and anecdotes, probably the most I've seen in a non-fiction/self-help book. I'll definitely be rereading this book in the future.",
+      "The only reason this book didn't get a 5 star rating is because there were quite a few parts of the book that seemed to be from the Psychology of Money, which is a similar book by the same author. I did enjoy it better than the former book though.",
+      "If you've read Psychology of Money by the same author, you'll like this book as well. If you haven't, just read this book instead.",
+    ],
+  },
+];
+
+export const booksRead2025: string[] = [
+  "Ego is the Enemy by Ryan Holiday",
+  "Discipline is Destiny by Ryan Holiday",
+  "Make it Stick by Peter C. Brown, Henry L. Roediger III, and Mark A. McDaniel",
+  "Psychology of Money by Morgan Housel",
+  "Can't Hurt Me by David Goggins",
+  "Hidden Potential by Adam Grant",
+  "How to Become a Straight-A Student by Cal Newport",
+  "Deep Work by Cal Newport",
+  "How to Love Someone Without Losing Your Mind by Todd Baratz",
+  "The Almanack of Naval Ravikant by Eric Jorgenson",
+  "What I Talk About When I Talk About Running by Haruki Murakami",
+  "Obliquity by John Kay",
+  "Thinking in Bets by Annie Duke",
+  "Man's Search for Meaning by Viktor Frankl",
+  "The Count of Monte Cristo by Alexandre Dumas",
+  "Educated by Tara Westover",
+  "Flowers for Algernon by Daniel Keyes",
+  "A Spy Among Friends by Ben Macintyre",
+  "East of Eden by John Steinbeck",
+  "1984 by George Orwell",
+];
+
+export const booksRead2026: string[] = [
+  "The Art of Spending Money by Morgan Housel",
+];

--- a/my-website/app/reading/page.tsx
+++ b/my-website/app/reading/page.tsx
@@ -5,170 +5,18 @@ import * as motion from "motion/react-client";
 import Layout from "../components/Layout";
 import BookReviewCard from "../components/BookReviewCard";
 import AnimatedBulletPoint from "../components/AnimatedBulletPoint";
+import {
+  currentlyReading,
+  bookReviews,
+  booksRead2025,
+  booksRead2026,
+} from "./data";
 
 const ReadingPage = () => {
-  const bookReviews = [
-    {
-      title: "Thinking in Bets",
-      author: "Annie Duke",
-      imageUrl: "https://m.media-amazon.com/images/I/71WOIOz0ihL._SY522_.jpg",
-      rating: 4,
-      review: [
-        "It is a good book for someone who wants to learn about decision making and how to make better decisions.",
-        "I got into it because I recently started playing poker and wanted to understand the psychology behind making decisions when you have incomplete information.",
-        "It's more of a theoretical book, but it's still a good read in my opinion.",
-      ],
-    },
-    {
-      title: "The Psychology of Money",
-      author: "Morgan Housel",
-      imageUrl: "https://images.renaud-bray.com/images/PG/3440/3440245-gf.jpg",
-      rating: 4,
-      review: [
-        "Great book for someone wanting to understand the emotional and psychological factors that drive our financial decisions. Talks a lot about how our upbringing and experiences shape the way we think about money.",
-        "Has a lot of good anecdotes that make the book engaging, and it's an easy read.",
-        "In a practical sense, Morgan Housel talks about how he approaches saving/investing, but it's not a how-to-book. I saw it more as an insightful book.",
-      ],
-    },
-    {
-      title: "Man's Search for Meaning",
-      author: "Viktor Frankl",
-      imageUrl: "https://m.media-amazon.com/images/I/612eTMIpONS._SY522_.jpg",
-      rating: 4.5,
-      review: [
-        "Great book. It was very touching, and there were multiple moments where I had to pause and reflect to try and imagine going through the inhumane conditions that the author and others in the concentration camps had to endure.",
-        "The book is about Viktor Frankl's experiences in the concentration camps during WW2 and how he found meaning in his life despite the horrors he endured. He also details methods for finding purpose, such as suffering with dignity.",
-        "Potentially one of the best books I've read this year.",
-      ],
-    },
-    {
-      title: "The Count of Monte Cristo",
-      author: "Alexandre Dumas",
-      imageUrl: "https://m.media-amazon.com/images/I/811iBn28JdL._SY522_.jpg",
-      rating: 5,
-      review: [
-        "This book is THE revenge tale, and probably one of the best books I've ever read.",
-        "The story follows Edmond Dantès, a young sailor who is wrongfully imprisoned and seeks revenge on those who betrayed him.",
-        "The way he goes about his retribution is both very clever and calculated, and despite being over 1200 pages long, it was a page-turner from start to finish. It has everything you could want in a book: adventure, romance, betrayal, and revenge.",
-        "This was my first time reading a fiction book in a long time, and I think I will get back into reading more fiction after this.",
-        "Amazing read, and a deserved 5 stars.",
-      ],
-    },
-    {
-      title: "Educated",
-      author: "Tara Westover",
-      imageUrl: "https://m.media-amazon.com/images/I/418dkB1gnxL.jpg",
-      rating: 4,
-      review: [
-        "Was a very interesting read, and rather empowering. This book follows the life of Tara, a woman who grew up in an extremely fundamentalist Mormon household, where she was denied access to education. It details how she gradually educates herself\
-                and eventually goes on to earn a PhD from Cambridge University.",
-        "The book is well-written and engaging. I got rather angry at some parts, especially when she detailed the abuse she and her siblings endured at the hands of their father/brother, and how her family refused to acknowledge it.\
-                I even got more frustrated when she kept going back to her family despite the abuse, but I guess that's the power of family.",
-        "It was inspiring overall, seeing someone overcome such adversity to attain such a high level of education. Overall a good read.",
-      ],
-    },
-    {
-      title: "Flowers for Algernon",
-      author: "Daniel Keyes",
-      imageUrl: "https://m.media-amazon.com/images/I/81HntONlwgL._SY522_.jpg",
-      rating: 4.5,
-      review: [
-        "This book was very touching. It follows the story of Charlie, a man who initially suffers from severe mental disabilities, but undergoes a brain surgery that gives him intelligence.",
-        "It reminded me of the importance of showing compassion and empathy towards people different from us. It was kind of sad at times to see how Charlie slowly realized that everyone around him didn't actually care about him, and made fun of him just because he was different.",
-        "It was also interesting to see how Charlie's intelligence grew over time, and made him less and less relatable, and even at times arrogant.",
-        "Seeing his eventual mental decline was very saddening, and it left me in a sort of somber mood for a while after reading it.",
-        "I'd recommend this book. It was the first time I've read a fiction book that was written in the form of journal entries, and it surely surpassed my expectations.",
-      ],
-    },
-    {
-      title: "A Spy Among Friends",
-      author: "Ben Macintyre",
-      imageUrl: "https://m.media-amazon.com/images/I/81grRR9GmML._SY522_.jpg",
-      rating: 4,
-      review: [
-        "This book is a non-fiction that tells the story of famed British spy Kim Philby, who was actually a double agent for the Soviet Union. It details his life, his relationships with other spies, and the eventual uncoverning of his betrayal.",
-        "It kind of surprised me how Philby was able to maintain his cover for so long, and how his closest friends backed him vehemently despite the mounting evidence against him. It was also kind of crazy how Philby basically undermined Western intelligence operations against the Soviets for two decades.",
-        "It gave me new perspective on betrayal, and how people can let their personal relationships get in the way of their professional responsibilities.",
-        "It was a good read, and it gave me a new perspective on the Cold War and the role of intelligence agencies in the push to change the ideological landscape of the world.",
-      ],
-    },
-    {
-      title: "East of Eden",
-      author: "John Steinbeck",
-      imageUrl: "https://m.media-amazon.com/images/I/71NAX4mpJHL._SY522_.jpg",
-      rating: 5,
-      review: [
-        "Possibly the best book I've ever read.",
-        "This book goes into the lives of two families, the Trasks and the Hamiltons, who lived in California. This book spans a couple of generations, from around the mid-19th century to the early 20th century.",
-        "It is essentially a modern American retelling of the biblical story of Cain and Abel, and the themes are rather prevalent throughout the book. Across each generation, you can draw parallels between the events in the story and the story from the Book of Genesis. It also touches on the themes of good and evil, examining whether humans can be inherently good or evil. It asks whether we are doomed to repeat the transgressions of our ancestors, or we can form our own moral paths.",
-        'A key word in this whole thing is Timshel, which was interpreted in East of Eden as "Thou mayest" (I understand that this is not the literal translation). In the context of the book, I think Steinbeck was trying to convey the message that humans have free will to choose whether to be good or evil, independent of what their nature may be.',
-        "The book was so wonderfully written. John Steinbeck's prose is rather straightforward, but very beautifully written. His characterization was also top notch, and I sort of grew attached to the characters in the book. Lee and Cal are my favourite characters in the book. Lee for his wisdom and charisma. Cal, because he was a flawed person, but he was a joy to follow, and his battles with identity and morality are things I can somewhat relate to.",
-        "I also loved following Cathy. She seemed to be evil for the sake of it, but that made her more interesting. I never figured out what her endgame was. Samuel Hamilton is probably my favourite character after Lee and Cal. He was the poster boy for someone following his dreams and passions.",
-        "All in all, this book was very enjoyable with a lot of wisdom scattered throughout the book, if you choose to look for it. Easy 5 star, and an easy recommendation from me.",
-      ],
-    },
-    {
-      title: "1984",
-      author: "George Orwell",
-      imageUrl:
-        "https://m.media-amazon.com/images/I/51yNeZ+SDOL._SY445_SX342_ControlCacheEqualizer_.jpg",
-      rating: 4,
-      review: [
-        "(Shorter Review because of exams)",
-        "It's a good book.",
-        "1984 is set in a dystopian, totalitarian province within the superstate of Oceania. Specifically, it's set in London, where its protagonist Winston lives and works under the watchful eye of The Party and its leader, Big Brother.",
-        "I found it a bit of a drag at first, but it picked up and got more interesting as the book went on.",
-        "I'd say it's pretty relevant today given current events in the world today, and it serves as a cautionary tale of some sorts. It does a good job of portraying a surveillance state, where the past is altered, and even the language is narrowed down to keep people as obedient as possible.",
-        "The book is worth reading, IMO.",
-      ],
-    },
-    {
-      title: "The Art of Spending Money",
-      author: "Morgan Housel",
-      imageUrl: "https://m.media-amazon.com/images/I/71Pusl9N1AL._SL1500_.jpg",
-      rating: 4.5,
-      review: [
-        "This book talks a lot about the different social and psychological factors that go into our spending habits, and how we can understand their effects on our financial well-being.",
-        "I resonated with a lot of the book, and I will definitely be using a lot of the advice in this book when I start my co-op job, as it will be the first time I have a good amount of disposable income.",
-        "The number one thing I took away from the book is that anyone's behavior makes sense with enough information. The person who lost all their money in the 2008/2009 financial crisis may be very conservative with their investments, but the young person who has never had to worry about money may be a lot less risk averse, or even reckless.",
-        "The author also had a very interesting way of looking at saving money. He viewed saving money as a payment, the same way you'd pay for clothes, or food. But when you save money, you are paying towards your future independence. So saving $100 dollars today could be seen as giving yourself $100 dollars of freedom tomorrow.",
-        "It is also important to not have FOMO, and walk your journey. Easier said than done, but you should have a view of what you want your life to look like, and stay true to it.",
-        "I believe this book is a great, practical book for people looking into helping people reshape their relationship with money. The book is also incredibly dense with great quotes and anecdotes, probably the most I've seen in a non-fiction/self-help book. I'll definitely be rereading this book in the future.",
-        "The only reason this book didn't get a 5 star rating is because there were quite a few parts of the book that seemed to be from the Psychology of Money, which is a similar book by the same author. I did enjoy it better than the former book though.",
-        "If you've read Psychology of Money by the same author, you'll like this book as well. If you haven't, just read this book instead.",
-      ],
-    },
-  ];
-
   const [showBooksRead, setShowBooksRead] = useState(false);
   const [showBooks2025, setShowBooks2025] = useState(false);
   const [showBooks2026, setShowBooks2026] = useState(false);
   const [showCurrentlyReading, setShowCurrentlyReading] = useState(false);
-
-  const booksRead2025 = [
-    "Ego is the Enemy by Ryan Holiday",
-    "Discipline is Destiny by Ryan Holiday",
-    "Make it Stick by Peter C. Brown, Henry L. Roediger III, and Mark A. McDaniel",
-    "Psychology of Money by Morgan Housel",
-    "Can't Hurt Me by David Goggins",
-    "Hidden Potential by Adam Grant",
-    "How to Become a Straight-A Student by Cal Newport",
-    "Deep Work by Cal Newport",
-    "How to Love Someone Without Losing Your Mind by Todd Baratz",
-    "The Almanack of Naval Ravikant by Eric Jorgenson",
-    "What I Talk About When I Talk About Running by Haruki Murakami",
-    "Obliquity by John Kay",
-    "Thinking in Bets by Annie Duke",
-    "Man's Search for Meaning by Viktor Frankl",
-    "The Count of Monte Cristo by Alexandre Dumas",
-    "Educated by Tara Westover",
-    "Flowers for Algernon by Daniel Keyes",
-    "A Spy Among Friends by Ben Macintyre",
-    "East of Eden by John Steinbeck",
-    "1984 by George Orwell",
-  ];
-
-  const booksRead2026 = ["The Art of Spending Money by Morgan Housel"];
 
   const listVariants = {
     hidden: { opacity: 0, height: 0 },
@@ -236,8 +84,8 @@ const ReadingPage = () => {
               <div className="space-y-4">
                 <div className="space-y-2 text-xl pl-4">
                   <AnimatedBulletPoint>
-                    <i>A Peace to End All Peace</i>
-                    <span className="ml-1"> by David Fromkin</span>
+                    <i>{currentlyReading.title}</i>
+                    <span className="ml-1"> by {currentlyReading.author}</span>
                   </AnimatedBulletPoint>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- Drops the profile photo; adds a small round avatar top-right
- Name scrambles on hover via a new `GlitchText` component
- Replaces Incoming/Currently/Previously/Some-things with four sections: **About**, **Reading**, **Experience**, **Writing**
- Experience: top 2 roles visible, "Show all" reveals the rest, each row expands in place for detail
- Reading: one-line currently-reading callout linking the title to an external URL plus a link to the full `/reading` page
- Writing: latest 3 MDX posts, titles + formatted dates, fetched server-side via `getAllArticles`
- Extracts reading data into `app/reading/data.ts` so Hero can import the current book without duplicating it
- Removes `/experiences` from the nav (route still exists for direct access)

## Why
The previous homepage was content-dense — four labeled sections, a 300px profile photo, and brand-colored company names. We wanted something sparer that still feels distinctive. The glitch-on-hover and avatar top-right give the page personality without adding visual noise.

## Test plan
- [ ] \`cd my-website && npm install && npm run dev\` — homepage renders
- [ ] Hover the name — letters scramble and resolve left-to-right
- [ ] Expand each experience row that has detail; toggle "Show all (6)" / "Show less"
- [ ] Reading title opens the Amazon URL in a new tab; "here" routes to \`/reading\`
- [ ] Writing titles route to \`/writing/[slug]\`; "All writing →" goes to \`/writing\`
- [ ] \`/experiences\` still loads directly but is absent from the nav (desktop + mobile)
- [ ] Light + dark mode, mobile + desktop breakpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it rewrites the homepage/hero layout and interaction patterns (new hover-scramble + accordion state) and changes the home route to fetch MDX article metadata server-side, which could affect rendering/SSG behavior.
> 
> **Overview**
> Redesigns the homepage `Hero` into a minimal, sectioned layout (**About**, **Reading**, **Experience**, **Writing**) with a small avatar header and a new `GlitchText` hover/focus scramble effect for the name.
> 
> Adds an expandable **Experience** list (initially shows top 2, “Show all/less”, per-row accordion details) and a **Writing** preview that displays the latest 3 MDX posts with formatted dates; `app/page.tsx` now fetches articles via `getAllArticles()` and passes them into `Hero`.
> 
> Extracts reading content into `app/reading/data.ts` (used by both home and `/reading`) and removes the `/experiences` link from the header navigation (desktop + mobile).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a4248cc2d7ec488b1e80ff9273a458a2f5bf478. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->